### PR TITLE
Hearus 활성화 yaml 업데이트

### DIFF
--- a/k8s/Express-Deployment.yaml
+++ b/k8s/Express-Deployment.yaml
@@ -5,10 +5,11 @@ metadata:
   labels:
     app.kubernetes.io/name: hearus-back
 spec:
+  type: LoadBalancer
   ports:
     - port: 3000
       targetPort: 3000
-      protocol: TCP
+      name: back-ws
   selector:
     app.kubernetes.io/name: hearus-back
 ---
@@ -28,8 +29,8 @@ spec:
         app.kubernetes.io/name: hearus-back
     spec:
       containers:
-      - image: judemin/hearus-back-node
+      - image: choijihyeok/hearus-back-node
         name: hearus-back
         ports:
         - containerPort: 3000
-          name: hearus-back
+          name: back-ws

--- a/k8s/Express-Deployment.yaml
+++ b/k8s/Express-Deployment.yaml
@@ -29,8 +29,11 @@ spec:
         app.kubernetes.io/name: hearus-back
     spec:
       containers:
-      - image: choijihyeok/hearus-back-node
+      - image: judemin/hearus-back-node
         name: hearus-back
+        env:
+        - name: FLASK_HOST
+          value: http://hearus-flask-svc.default.svc.cluster.local/
         ports:
         - containerPort: 3000
           name: back-ws

--- a/k8s/Express-Ingress.yaml
+++ b/k8s/Express-Ingress.yaml
@@ -18,17 +18,3 @@ spec:
               name: hearus-front-svc
               port:
                 number: 80
-        - pathType: Prefix
-          path: /transcribe
-          backend:
-            service:
-              name: hearus-flask-svc
-              port:
-                number: 5000
-        - pathType: Prefix
-          path: /process
-          backend:
-            service:
-              name: hearus-flask-svc
-              port:
-                number: 5000

--- a/k8s/Express-Ingress.yaml
+++ b/k8s/Express-Ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hearus-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/subnets: Hearus-project-vpc-public-ap-northeast-2a, Hearus-project-vpc-public-ap-northeast-2c
+spec:
+  rules:
+  - http:
+       paths:
+        - pathType: Prefix
+          path: /
+          backend:
+            service:
+              name: hearus-front-svc
+              port:
+                number: 80
+        - pathType: Prefix
+          path: /transcribe
+          backend:
+            service:
+              name: hearus-flask-svc
+              port:
+                number: 5000
+        - pathType: Prefix
+          path: /process
+          backend:
+            service:
+              name: hearus-flask-svc
+              port:
+                number: 5000

--- a/k8s/Flask-Deployment.yaml
+++ b/k8s/Flask-Deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hearus-flask-svc
+  labels:
+    app.kubernetes.io/name: hearus-flask
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5000
+      targetPort: 5000
+      name: hearus-flask
+  selector:
+    app.kubernetes.io/name: hearus-flask
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hearus-flask
+  labels:
+    app.kubernetes.io/name: hearus-flask
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hearus-flask
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hearus-flask
+    spec:
+      containers:
+      - image: judemin/hearus-flask-serving
+        name: hearus-flask
+        ports:
+        - containerPort: 5000
+          name: hearus-flask

--- a/k8s/Flask-Deployment.yaml
+++ b/k8s/Flask-Deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 5000
+    - port: 80
       targetPort: 5000
       name: hearus-flask
   selector:

--- a/k8s/Vue-Deployment.yaml
+++ b/k8s/Vue-Deployment.yaml
@@ -8,6 +8,8 @@ spec:
   type: LoadBalancer
   ports:
     - port: 80
+      targetPort: 80
+      name: hearus-front
   selector:
     app.kubernetes.io/name: hearus-front
 ---


### PR DESCRIPTION
현재 활성화 된 Hearus 서비스를 실행하기 위한 yaml 파일 업로드

Express-Deployment.yaml
Vue-Deployment.yaml

위 두 파일은 현재 choijihyeok/hearus-front-vue 이미지와 choijihyeok/hearus-back-node 이미지를 사용합니다.

Vue와 Express에 작성해야하는 주소를 변경했기 때문입니다.

추후 환경변수를 주입하는 방법을 찾거나, FQDN을 사용하는 방법을 찾게 되어 적용한다면 이미지를 따로 쓰지 않아도 될 것으로 생각됩니다.