### PR TITLE
hearus service 연결

### DIFF
--- a/k8s/Express-Deployment.yaml
+++ b/k8s/Express-Deployment.yaml
@@ -5,9 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: hearus-back
 spec:
-  type: LoadBalancer
+  type: NodePort
+  sessionAffinity: ClientIP
   ports:
-    - port: 3000
+    - port: 80
       targetPort: 3000
       name: back-ws
   selector:

--- a/k8s/Express-Ingress.yaml
+++ b/k8s/Express-Ingress.yaml
@@ -7,10 +7,19 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/subnets: Hearus-project-vpc-public-ap-northeast-2a, Hearus-project-vpc-public-ap-northeast-2c
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=600
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=60
 spec:
   rules:
   - http:
-       paths:
+      paths:
+        - pathType: Prefix
+          path: /socket.io/
+          backend:
+            service:
+              name: hearus-back-svc
+              port:
+                number: 80
         - pathType: Prefix
           path: /
           backend:

--- a/k8s/Flask-Deployment.yaml
+++ b/k8s/Flask-Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: hearus-flask
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 80
       targetPort: 5000

--- a/k8s/Vue-Deployment.yaml
+++ b/k8s/Vue-Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/name: hearus-front
     spec:
       containers:
-      - image: choijihyeok/hearus-front-vue
+      - image: judemin/hearus-front-vue
         name: hearus-front
         ports:
         - containerPort: 80


### PR DESCRIPTION
front를 제외한 나머지 서비스(Express, Flask)는 NodePort와 ClusterIP를 사용
vue의 환경 변수인 VUE_APP_BACKEND_HOST의 값을 AWS의 ALB 주소로 변경 후 사용
http://k8s-default-hearusin-86d19268c6-1974874804.ap-northeast-2.elb.amazonaws.com